### PR TITLE
Update AI model configuration to use gpt-3.5-turbo across the application

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -53,7 +53,7 @@ def generate_debate_response(
         response = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=messages,
-            max_tokens=500,
+            max_completion_tokens=500,
             temperature=0.7,
             presence_penalty=0.6,
             frequency_penalty=0.3,


### PR DESCRIPTION
- Changed default OpenAI model from gpt-5-nano to gpt-3.5-turbo in .env.example, README.md, and docker-compose.yml.
- Updated DECISION.md to reflect the new model choice and its parameters.
- Modified streamlit_app.py to utilize gpt-3.5-turbo for generating debate responses.